### PR TITLE
seller_idとbuyer_idのWHEREをUNION化してindexを利用させる

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -890,14 +890,12 @@ func getTransactions(w http.ResponseWriter, r *http.Request) {
 	if itemID > 0 && createdAt > 0 {
 		// paging
 		err := tx.Select(&items,
-			"SELECT * FROM `items` WHERE (`seller_id` = ? OR `buyer_id` = ?) AND `status` IN (?,?,?,?,?) AND (`created_at` < ?  OR (`created_at` <= ? AND `id` < ?)) ORDER BY `created_at` DESC, `id` DESC LIMIT ?",
+			"SELECT * FROM `items` WHERE `seller_id` = ? AND (`created_at` < ?  OR (`created_at` <= ? AND `id` < ?)) UNION SELECT * FROM `items` WHERE `buyer_id` = ? AND (`created_at` < ?  OR (`created_at` <= ? AND `id` < ?)) ORDER BY `created_at` DESC, `id` DESC LIMIT ? ",
 			user.ID,
+			time.Unix(createdAt, 0),
+			time.Unix(createdAt, 0),
+			itemID,
 			user.ID,
-			ItemStatusOnSale,
-			ItemStatusTrading,
-			ItemStatusSoldOut,
-			ItemStatusCancel,
-			ItemStatusStop,
 			time.Unix(createdAt, 0),
 			time.Unix(createdAt, 0),
 			itemID,
@@ -912,14 +910,9 @@ func getTransactions(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// 1st page
 		err := tx.Select(&items,
-			"SELECT * FROM `items` WHERE (`seller_id` = ? OR `buyer_id` = ?) AND `status` IN (?,?,?,?,?) ORDER BY `created_at` DESC, `id` DESC LIMIT ?",
+			"SELECT * FROM `items` WHERE `seller_id` = ? UNION SELECT * FROM `items` WHERE `buyer_id` = ? ORDER BY `created_at` DESC, `id` DESC LIMIT ?",
 			user.ID,
 			user.ID,
-			ItemStatusOnSale,
-			ItemStatusTrading,
-			ItemStatusSoldOut,
-			ItemStatusCancel,
-			ItemStatusStop,
 			TransactionsPerPage+1,
 		)
 		if err != nil {

--- a/sql/03_patch.sql
+++ b/sql/03_patch.sql
@@ -1,7 +1,8 @@
-ALTER TABLE `items` ADD INDEX idx_status_created_at (`status`, `created_at` DESC);
-ALTER TABLE `items` ADD INDEX idx_status_category_created_at (`status`, `category_id`, `created_at` DESC);
-ALTER TABLE `items` ADD INDEX idx_seller_status_created_at (`seller_id`, `status`, `created_at` DESC);
-ALTER TABLE `items` ADD INDEX idx_seller_buyer_status_created_at (`seller_id`, `buyer_id`, `status`, `created_at` DESC);
+ALTER TABLE `items` ADD INDEX idx_created_at (`created_at`);
+ALTER TABLE `items` ADD INDEX idx_status_category_created_at (`status`, `category_id`, `created_at`);
+ALTER TABLE `items` ADD INDEX idx_seller_status_created_at (`seller_id`, `status`, `created_at`);
+ALTER TABLE `items` ADD INDEX idx_seller_buyer_status_created_at (`seller_id`, `status`, `created_at`);
+ALTER TABLE `items` ADD INDEX idx_seller_buyer_status_created_at (`buyer_id`, `status`, `created_at`);
 ALTER TABLE `transaction_evidences` ADD INDEX idx_item_id (`item_id`);
 ALTER TABLE `shippings` ADD INDEX idx_transaction_evidence_id (`transaction_evidence_id`);
 ALTER TABLE `users` ADD INDEX idx_account_name (`account_name`);

--- a/sql/03_patch.sql
+++ b/sql/03_patch.sql
@@ -1,8 +1,7 @@
 ALTER TABLE `items` ADD INDEX idx_created_at (`created_at`);
 ALTER TABLE `items` ADD INDEX idx_status_category_created_at (`status`, `category_id`, `created_at`);
-ALTER TABLE `items` ADD INDEX idx_seller_status_created_at (`seller_id`, `status`, `created_at`);
-ALTER TABLE `items` ADD INDEX idx_seller_buyer_status_created_at (`seller_id`, `status`, `created_at`);
-ALTER TABLE `items` ADD INDEX idx_seller_buyer_status_created_at (`buyer_id`, `status`, `created_at`);
+ALTER TABLE `items` ADD INDEX idx_buyer_id_created_at (`seller_id`, `created_at`);
+ALTER TABLE `items` ADD INDEX idx_seller_id_created_at (`buyer_id`, `created_at`);
 ALTER TABLE `transaction_evidences` ADD INDEX idx_item_id (`item_id`);
 ALTER TABLE `shippings` ADD INDEX idx_transaction_evidence_id (`transaction_evidence_id`);
 ALTER TABLE `users` ADD INDEX idx_account_name (`account_name`);


### PR DESCRIPTION
以下のクエリでindexを利用できていなかったのでUNIONに分解する

```
mysql> explain SELECT * FROM `items` WHERE (`seller_id` = 813 OR `buyer_id` = 813) AND `status` IN ('on_sale','trading','sold_out','cancel','stop') ORDER BY `created_at` DESC, `id` DESC LIMIT 11\G;
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: items
   partitions: NULL
         type: ALL
possible_keys: idx_status_created_at,idx_status_category_created_at,idx_seller_status_created_at,idx_seller_buyer_status_created_at
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 43842
     filtered: 10.24
        Extra: Using where; Using filesort
1 row in set, 1 warning (0.00 sec)

ERROR:
No query specified
```