### PR TITLE
新着商品でユーザーが過去に購入したカテゴリの商品を返す

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -2171,11 +2171,12 @@ func postSell(w http.ResponseWriter, r *http.Request) {
 		outputErrorMsg(w, http.StatusInternalServerError, "db error")
 		return
 	}
-	tx.Commit()
 
 	userSimpleMutex.Lock()
 	userSimpleCache[seller.ID].NumSellItems = seller.NumSellItems + 1
 	userSimpleMutex.Unlock()
+
+	tx.Commit()
 
 	w.Header().Set("Content-Type", "application/json;charset=utf-8")
 	json.NewEncoder(w).Encode(resSell{ID: itemID})

--- a/go/main.go
+++ b/go/main.go
@@ -565,7 +565,7 @@ func getNewItems(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	category := Category{}
-	err = dbx.Select(&category, "SELECT i.`category_id` FROM `users` AS u INNER JOIN `items` AS i on u.`id` = i.`buyer_id` where u.`id` = ? LIMIT 1", user.ID)
+	err = dbx.Get(&category, "SELECT i.`category_id` FROM `users` AS u INNER JOIN `items` AS i on u.`id` = i.`buyer_id` where u.`id` = ? LIMIT 1", user.ID)
 	if err != nil {
 		log.Print(err)
 		outputErrorMsg(w, http.StatusInternalServerError, "db error")

--- a/go/main.go
+++ b/go/main.go
@@ -564,8 +564,8 @@ func getNewItems(w http.ResponseWriter, r *http.Request) {
 		outputErrorMsg(w, errCode, errMsg)
 		return
 	}
-	category := Category{}
-	err = dbx.Get(&category, "SELECT i.`category_id` FROM `users` AS u INNER JOIN `items` AS i on u.`id` = i.`buyer_id` where u.`id` = ? LIMIT 1", user.ID)
+	var categoryID int64
+	err = dbx.Get(&categoryID, "SELECT i.`category_id` FROM `users` AS u INNER JOIN `items` AS i on u.`id` = i.`buyer_id` where u.`id` = ? LIMIT 1", user.ID)
 	if err != nil {
 		log.Print(err)
 		outputErrorMsg(w, http.StatusInternalServerError, "db error")
@@ -579,7 +579,7 @@ func getNewItems(w http.ResponseWriter, r *http.Request) {
 			"SELECT * FROM `items` WHERE `status` IN (?,?) AND category_id = ? AND (`created_at` < ?  OR (`created_at` <= ? AND `id` < ?)) ORDER BY `created_at` DESC, `id` DESC LIMIT ?",
 			ItemStatusOnSale,
 			ItemStatusSoldOut,
-			category.ID,
+			categoryID,
 			time.Unix(createdAt, 0),
 			time.Unix(createdAt, 0),
 			itemID,
@@ -596,7 +596,7 @@ func getNewItems(w http.ResponseWriter, r *http.Request) {
 			"SELECT * FROM `items` WHERE `status` IN (?,?) AND category_id = ? ORDER BY `created_at` DESC, `id` DESC LIMIT ?",
 			ItemStatusOnSale,
 			ItemStatusSoldOut,
-			category.ID,
+			categoryID,
 			ItemsPerPage+1,
 		)
 		if err != nil {


### PR DESCRIPTION
以下の一文より新着一覧はユーザーに合わせた商品を返せることがわかる。

> 新着一覧については、上記の制限を満たした上でよりユーザにあわせた商品の一覧を返すことで、購入の機会を増やすことができます。

SQLを叩いたところユーザーは1つのカテゴリのみから商品を購入していることがわかった

```
mysql> select u.id, i.price, i.category_id from users as u inner join items as i on u.id = i.buyer_id where u.id = 2410;
+------+-------+-------------+
| id   | price | category_id |
+------+-------+-------------+
| 2410 |   100 |          11 |
| 2410 |   100 |          11 |
| 2410 |   100 |          11 |
| 2410 |   100 |          11 |
+------+-------+-------------+
4 rows in set (0.01 sec)

mysql> select u.id, i.price, i.category_id from users as u inner join items as i on u.id = i.buyer_id where u.id = 3421;
+------+-------+-------------+
| id   | price | category_id |
+------+-------+-------------+
| 3421 |   100 |          42 |
| 3421 |   100 |          42 |
| 3421 |   100 |          42 |
| 3421 |   100 |          42 |
+------+-------+-------------+
4 rows in set (0.01 sec)
```